### PR TITLE
Fixed vulnerability with superagent dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -955,7 +955,7 @@
       }
     },
     "supertest": {
-      "version": "1.2.0",
+      "version": ">=3.7.0",
       "resolved": "https://registry.npmjs.org/supertest/-/supertest-1.2.0.tgz",
       "integrity": "sha1-hQp5X5Bo0vrxngF5n/CZYuDOQ74=",
       "dev": true,


### PR DESCRIPTION
Changed the version number of the superagent dependency to >=3.7.0, which patches a security vulnerability.