### PR TITLE
Upgraded version of supertest to resolve security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
   },
   "devDependencies": {
     "should": "^7.1.1",
-    "supertest": "^1.1.0"
+    "supertest": "^3.1.0"
   }
 }


### PR DESCRIPTION
The older version of supertest required an insecure version of superagent. Upgraded the version of the devDependency to fix this. 